### PR TITLE
Fix nil pointer error with bad URL

### DIFF
--- a/fastimage.go
+++ b/fastimage.go
@@ -15,11 +15,11 @@ func DetectImageType(uri string) (ImageType, *ImageSize, error) {
 	logger.Printf("Opening HTTP stream")
 	resp, err := http.Get(uri)
 
-	defer closeHTTPStream(resp)
-
 	if err != nil {
 		return Unknown, nil, err
 	}
+
+	defer closeHTTPStream(resp)
 
 	return DetectImageTypeFromResponse(resp)
 }


### PR DESCRIPTION
Previously even if there was an error opening the HTTP stream, it would still defer closing the stream, which would end up with a nil pointer error since the stream was never successfully opened. I moved the `defer closeHTTPStream()` to below the error handler to avoid these issues.