### PR TITLE
Replace SetTimeout() with DetectImageTypeWithTimeout() to remove global mutable state

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ At the end, you can read something like this:
 
     Closed after reading just 17863 bytes out of 10001439 bytes
 
+If you want to set request timeout for url:
+
+    // the second argument is request timeout (milliseconds).
+    // FYI, DetectImageType() uses default timeout 5000ms.
+    imagetype, size, err := fastimage.DetectImageTypeWithTimeout(url, 2000)
+
 ## Supported file types
 
 | File type | Can detect type? | Can detect size? |

--- a/fastimage.go
+++ b/fastimage.go
@@ -9,27 +9,28 @@ import (
 
 const defaultTimeout = time.Duration(5000) * time.Millisecond
 
-// Request timeout
-var timeout = defaultTimeout
-
-// SetTimeout sets a time limit (millisecond) for requests.
-//
-// If ms < 1, defaultTimeout(5000) is set.
-func SetTimeout(ms int) {
-	if ms < 1 {
-		timeout = defaultTimeout
-	}
-	timeout = time.Duration(ms) * time.Millisecond
-}
-
 // DetectImageType is the main function used to detect the type and size
 // of a remote image represented by the url.
 //
 // Only check ImageType and ImageSize if error is not nil.
+//
+// If you want to set request timeout for uri, use DetectImageTypeWithTimeout() instead.
 func DetectImageType(uri string) (ImageType, *ImageSize, error) {
+	return DetectImageTypeWithTimeout(uri, 0)
+}
 
+// DetectImageTypeWithTimeout acts same as DetectImageType(),
+// except this function takes additional parameter timeout (millisecond)
+// for setting request timeout.
+//
+// If timeout < 1, default timeout 5000 is used.
+func DetectImageTypeWithTimeout(uri string, timeout int) (ImageType, *ImageSize, error) {
 	logger.Printf("Opening HTTP stream")
-	client := &http.Client{Timeout: timeout}
+	t := time.Duration(timeout) * time.Millisecond
+	if timeout < 1 {
+		t = defaultTimeout
+	}
+	client := &http.Client{Timeout: t}
 	resp, err := client.Get(uri)
 
 	if err != nil {

--- a/fastimage_test.go
+++ b/fastimage_test.go
@@ -2,17 +2,6 @@ package fastimage
 
 import "testing"
 
-func TestTimeout(t *testing.T) {
-	url := "http://osmanias.com/data/file/all_gallery/3076878222_lLrpiAG6_e0780a92ec70d60b8ab47fde6575fba65120559a.jpg"
-
-	SetTimeout(1)
-	_, _, err := DetectImageType(url)
-	SetTimeout(0)
-	if err == nil {
-		t.Error("Timeout expected, but not occurred")
-	}
-}
-
 func TestPNGImage(t *testing.T) {
 	t.Parallel()
 
@@ -131,4 +120,15 @@ func TestTIFFImage(t *testing.T) {
 		t.Error("We can't detect TIFF size yet")
 	}
 
+}
+
+func TestCustomTimeout(t *testing.T) {
+	t.Parallel()
+
+	url := "http://osmanias.com/data/file/all_gallery/3076878222_lLrpiAG6_e0780a92ec70d60b8ab47fde6575fba65120559a.jpg"
+
+	_, _, err := DetectImageTypeWithTimeout(url, 1)
+	if err == nil {
+		t.Error("Timeout expected, but not occurred")
+	}
 }


### PR DESCRIPTION
Sorry to bother you. My previous PR has global mutable state `timeout`, which is not thread-safe.