### PR TITLE
Set timeout for DetectImageTypeFromReader()

### DIFF
--- a/fastimage.go
+++ b/fastimage.go
@@ -63,6 +63,9 @@ func DetectImageTypeFromReader(r io.Reader) (ImageType, *ImageSize, error) {
 		if buffer.Len() < 2 {
 			continue
 		}
+		if buffer.Len() > 20000 {
+			return Unknown, nil, err
+		}
 
 		if err != nil {
 			logger.Printf("Bailing out because of err %v", err)
@@ -78,6 +81,7 @@ func DetectImageTypeFromReader(r io.Reader) (ImageType, *ImageSize, error) {
 					logger.Printf("Found image type %v with size %v", t, size)
 					return t, size, nil
 				}
+				break
 			}
 		}
 	}

--- a/fastimage_benchmark_test.go
+++ b/fastimage_benchmark_test.go
@@ -2,21 +2,13 @@ package fastimage
 
 import "testing"
 
-// func BenchmarkSample(b *testing.B) {
-// 	for i := 0; i < b.N; i++ {
-// 		if x := fmt.Sprintf("%d", 42); x != "42" {
-// 			b.Fatalf("Unexpected string: %s", x)
-// 		}
-// 	}
-// }
-
 func BenchmarkCustomTimeout(b *testing.B) {
 	// url := "http://upload.wikimedia.org/wikipedia/commons/9/9a/SKA_dishes_big.jpg"
 	url := "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_120x44dp.png"
 	// url := "http://loremflickr.com/500/500"
 
 	for i := 0; i < b.N; i++ {
-		it, is, err := DetectImageTypeWithTimeout(url, 10000)
+		it, is, err := DetectImageTypeWithTimeout(url, 1000)
 		b.Logf("type:%v, size:%v, err:%v", it, is, err)
 	}
 }

--- a/fastimage_test.go
+++ b/fastimage_test.go
@@ -129,7 +129,7 @@ func TestCustomTimeout(t *testing.T) {
 
 	url := "http://loremflickr.com/500/500"
 
-	imagetype, size, err := DetectImageTypeWithTimeout(url, 5000)
+	imagetype, size, err := DetectImageTypeWithTimeout(url, 1000)
 	t.Logf("imageType: %v", imagetype)
 	t.Logf("size: %v", size)
 	t.Logf("error: %v", err)


### PR DESCRIPTION
When used in a goroutine on heavy traffic, DetectImageTypeFromReader() caused high CPU usage and load.
